### PR TITLE
Change module name in Gradle section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly group: 'com.voxelgameslib', name: 'voxelgameslib', version: '1.0.0-SNAPSHOT'
+    compileOnly group: 'com.voxelgameslib', name: 'voxelgameslib-parent', version: '1.0.0-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
`voxelgameslib` changed to `voxelgameslib-parent` because `voxelgameslib` doesn't exist on https://repo.minidigger.me/repository/maven-public/